### PR TITLE
Converted panic to an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var m1, m2 map[string]interface{}
 json.Unmarshal(buf1, &m1)
 json.Unmarshal(buf2, &m2)
 
-merged := mergemap.Merge(m1, m2)
+merged, err := mergemap.Merge(m1, m2)
 ```
 
 See the test file for some pretty straightforward examples.

--- a/mergemap.go
+++ b/mergemap.go
@@ -1,6 +1,7 @@
 package mergemap
 
 import (
+	"errors"
 	"reflect"
 )
 
@@ -10,13 +11,13 @@ var (
 
 // Merge recursively merges the src and dst maps. Key conflicts are resolved by
 // preferring src, or recursively descending, if both src and dst are maps.
-func Merge(dst, src map[string]interface{}) map[string]interface{} {
+func Merge(dst, src map[string]interface{}) (map[string]interface{}, error) {
 	return merge(dst, src, 0)
 }
 
-func merge(dst, src map[string]interface{}, depth int) map[string]interface{} {
+func merge(dst, src map[string]interface{}, depth int) (map[string]interface{}, error) {
 	if depth > MaxDepth {
-		panic("too deep!")
+		return nil, errors.New("mergemap: maps too deeply nested")
 	}
 	for key, srcVal := range src {
 		if dstVal, ok := dst[key]; ok {
@@ -28,7 +29,7 @@ func merge(dst, src map[string]interface{}, depth int) map[string]interface{} {
 		}
 		dst[key] = srcVal
 	}
-	return dst
+	return dst, nil
 }
 
 func mapify(i interface{}) (map[string]interface{}, bool) {

--- a/mergemap.go
+++ b/mergemap.go
@@ -24,7 +24,11 @@ func merge(dst, src map[string]interface{}, depth int) (map[string]interface{}, 
 			srcMap, srcMapOk := mapify(srcVal)
 			dstMap, dstMapOk := mapify(dstVal)
 			if srcMapOk && dstMapOk {
-				srcVal = merge(dstMap, srcMap, depth+1)
+				var err error
+				srcVal, err = merge(dstMap, srcMap, depth+1)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		dst[key] = srcVal

--- a/mergemap_test.go
+++ b/mergemap_test.go
@@ -66,7 +66,7 @@ func TestMerge(t *testing.T) {
 			continue
 		}
 
-		got := Merge(dst, src)
+		got, _ := Merge(dst, src)
 		assert(t, expected, got)
 	}
 }


### PR DESCRIPTION
https://code.google.com/p/go-wiki/wiki/PanicAndRecover

By convention, no explicit panic() should be allowed to cross a package boundary. Indicating error conditions to callers should be done by returning error value.
