### PR TITLE
Converted panic to an error

### DIFF
--- a/mergemap_test.go
+++ b/mergemap_test.go
@@ -66,7 +66,7 @@ func TestMerge(t *testing.T) {
 			continue
 		}
 
-		got := Merge(dst, src)
+		got, _ := Merge(dst, src)
 		assert(t, expected, got)
 	}
 }


### PR DESCRIPTION
https://code.google.com/p/go-wiki/wiki/PanicAndRecover

By convention, no explicit panic() should be allowed to cross a package boundary. Indicating error conditions to callers should be done by returning error value.
