### PR TITLE
Merge slice values

### DIFF
--- a/mergemap.go
+++ b/mergemap.go
@@ -20,6 +20,10 @@ func merge(dst, src map[string]interface{}, depth int) map[string]interface{} {
 	}
 	for key, srcVal := range src {
 		if dstVal, ok := dst[key]; ok {
+			srcSlice, sliceOk := mergeSlices(srcVal, dstVal)
+			if sliceOk {
+				srcVal = srcSlice
+			}
 			srcMap, srcMapOk := mapify(srcVal)
 			dstMap, dstMapOk := mapify(dstVal)
 			if srcMapOk && dstMapOk {
@@ -41,4 +45,19 @@ func mapify(i interface{}) (map[string]interface{}, bool) {
 		return m, true
 	}
 	return map[string]interface{}{}, false
+}
+
+func mergeSlices(src, dst interface{}) (interface{}, bool) {
+	srcSlice, srcOk := src.([]interface{})
+	dstSlice, dstOk := dst.([]interface{})
+
+	if !(srcOk && dstOk) {
+		return nil, false
+	}
+
+	if !reflect.DeepEqual(srcSlice, dstSlice) {
+		srcSlice = append(srcSlice, dstSlice...)
+	}
+
+	return srcSlice, true
 }

--- a/mergemap_test.go
+++ b/mergemap_test.go
@@ -47,6 +47,11 @@ func TestMerge(t *testing.T) {
 			dst:      `{"1": {        "2": { "3": {"a":"A",        "n":"xxx"} }, "a":3 }}`,
 			expected: `{"1": { "b":1, "2": { "3": {"a":"A", "b":3, "n":[1,2]} }, "a":3 }}`,
 		},
+		{
+			src:      `{"1": {"a": "str1", "b": ["arr1", "arr2"]}}`,
+			dst:      `{"1": {             "b": ["arr3"],                 "c": "str2" }}`,
+			expected: `{"1": {"a": "str1", "b": ["arr1", "arr2", "arr3"], "c": "str2" }}`,
+		},
 	} {
 		var dst map[string]interface{}
 		if err := json.Unmarshal([]byte(tuple.dst), &dst); err != nil {


### PR DESCRIPTION
Hello, 

Currently this package only supports merging `map[string]interface{}` values, for everything else it chooses `src` value. 

In this PR I have added ability to merge two `[]interface{}` values if they are not identical. I don't need deduplication during merge of slices, but I would glad to hear your opinion on this feature. Maybe it could be configurable with options, e. g. `WithSliceDeduplication()`?

Closes #6. 

Alex. 